### PR TITLE
bug fix

### DIFF
--- a/tmob-demo/UsersScene/ViewController/UsersViewController.swift
+++ b/tmob-demo/UsersScene/ViewController/UsersViewController.swift
@@ -53,6 +53,7 @@ class UsersViewController: UIViewController {
         viewModel.users
             .drive(tableView.rx.items(cellIdentifier: "Cell", cellType: UITableViewCell.self)) { (row, element, cell) in
                 cell.textLabel?.text = element.login
+                cell.backgroundColor = UIColor.white
                 if let avatarUrl = try? URL(string: element.avatar_url){
                     //TODO ADD PLACEHOLDER
                     cell.imageView?.kf.setImage(with: avatarUrl) { result in


### PR DESCRIPTION
UITableViewCell background color was populating when recycling on extended RX class. 

Fixed by making all the background colors white initially on each recycle